### PR TITLE
The backend dependencies now automatically install on devcontainer build!

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -59,6 +59,11 @@ RUN add-apt-repository ppa:deadsnakes/ppa \
 RUN python3 -m ensurepip
 RUN python3 -m pip install --upgrade setuptools
 
+# Install Database Dependencies
+COPY backend/requirements.txt /workspaces/SOTestingEnv/backend/requirements.txt
+WORKDIR /workspaces/SOTestingEnv/backend
+RUN python3 -m pip install -r requirements.txt
+
 
 # Use a non-root user per https://code.visualstudio.com/remote/advancedcontainers/add-nonroot-user
 ARG USERNAME=vscode

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,8 @@
     "name": "Science Olympiad Testing Environment",
     "remoteUser": "vscode",
     "build": {
-        "dockerfile": "Dockerfile"
+        "dockerfile": "Dockerfile",
+        "context": ".."
     },
     "forwardPorts": [4400, 4401, 4402],
     "customizations": {

--- a/README.md
+++ b/README.md
@@ -19,9 +19,7 @@ Run the following commands:
 
 1. `cd frontend`
 2. `npm install` to install React dependencies
-3. `cd ../backend`
-4. `python3 -m pip install -r requirements.txt` to install FastAPI & SQLModel dependencies (This must be run every time the container is rebuilt)
-5. `python3 -m backend.script.reset_database` to create the database and load in fake data. This can be run as many times as possible to reset the databse.
+3. `python3 -m backend.script.reset_database` to create the database and load in fake data. This can be run as many times as possible to reset the databse.
 
 ### Running the Development Server
 


### PR DESCRIPTION
Adjusted a few files (see commit messages) in the docker setup to now allow the backend dependencies to be installed when the devcontainer is built. So as long as the `requirements.txt` is kept up to date via:

> anytime you install a new python package, "save" it to the `requirements.txt` via `python3 -m pip freeze > backend/requirements.txt` 

Then anytime we pull changes and notice we're missing a package all we need to do is rebuild the devcontainer! (`Ctrl/Cmd + P` and run `Dev Containers: Rebuild and Reopen Container`) then everything will be setup for us! (You can also just install that package lamo, but this is for those working after us)