### PR TITLE
Tests for questions service

### DIFF
--- a/backend/test/fake_data/question.py
+++ b/backend/test/fake_data/question.py
@@ -1,0 +1,89 @@
+import os
+import pytest
+
+__authors__ = ["Matthew Futch"]
+
+
+@pytest.fixture
+def setup_questions(tmp_path):
+    def create_environment(number_of_questions=2):
+        questions_dir = tmp_path / "es_files" / "questions"
+        global_docs_dir = tmp_path / "es_files" / "global_docs"
+        questions_dir.mkdir(parents=True)
+        global_docs_dir.mkdir(parents=True)
+
+        for i in range(1, number_of_questions + 1):
+            question_dir = questions_dir / f"q{i}"
+            question_dir.mkdir()
+
+            prompt_file = question_dir / "prompt.md"
+            local_doc_file = question_dir / "doc_foo.md"
+            starter_code_file = question_dir / "starter.py"
+
+            prompt_file.write_text(
+                f"# Question {i}\nThis is the prompt for question {i}.",
+                encoding="utf-8",
+            )
+            local_doc_file.write_text(
+                f"# Documentation {i}\nThis is the test documentation for question {i} in testing.",
+                encoding="utf-8",
+            )
+            starter_code_file.write_text("starter code")
+
+        global_doc_file = global_docs_dir / "gd.md"
+        global_doc_file.write_text(
+            "# Global Docs\nThis is a global document.", encoding="utf-8"
+        )
+
+        return tmp_path
+
+    return create_environment
+
+
+@pytest.fixture
+def setup_bad_questions(tmp_path):
+    def create_bad_environment(number_of_questions=2):
+        questions_dir = tmp_path / "es_files" / "questions"
+        global_docs_dir = tmp_path / "es_files" / "global_docs"
+        questions_dir.mkdir(parents=True)
+        global_docs_dir.mkdir(parents=True)
+
+        for i in range(1, number_of_questions + 1):
+            question_dir = questions_dir / f"q{i}"
+            question_dir.mkdir()
+
+            prompt_file = question_dir / "prompt.md"
+            local_doc_file = question_dir / "doc_foo.md"
+            prompt_file.write_text(
+                f"# Question {i}\nThis is the prompt for question {i}.",
+                encoding="utf-8",
+            )
+
+            local_doc_file.write_text(
+                f"# Documentation {i}\nThis is the test documentation for question {i} in testing.",
+                encoding="utf-8",
+            )
+            os.chmod(
+                local_doc_file, 0o000
+            )  # sets file permissions to 000 (no read/write/execute)
+
+        for i in range(1, 4):
+            bad_doc_file = global_docs_dir / f"doc{i}.md"
+            if i == 1:
+                bad_doc_file.write_text(
+                    "This document has restricted access."
+                )  # change access perms
+                os.chmod(bad_doc_file, 0o000)
+            elif i == 2:
+                bad_doc_file.write_bytes(
+                    b"\x80\x81\x82Invalid binary content"
+                )  # has binary data so cant read
+            else:
+                bad_doc_file.write_text("baddoc")
+                os.rename(
+                    bad_doc_file, global_docs_dir / f"doc{3}.png"
+                )  # different file extension
+
+        return tmp_path
+
+    return create_bad_environment

--- a/backend/test/question_test.py
+++ b/backend/test/question_test.py
@@ -1,0 +1,58 @@
+"""File to contain all Question related tests"""
+
+from ..models import Question, QuestionsPublic, Document
+import os
+import pytest
+from .fixtures import question_svc
+from ..test.fake_data.question import setup_questions, setup_bad_questions
+
+__authors__ = ["Matthew Futch"]
+
+
+def test_isQuestionDir(question_svc):
+    assert question_svc.isQuestionDir("q1000")
+    assert not question_svc.isQuestionDir("1z")
+
+
+def test_get_questions(question_svc, setup_questions):
+    number_of_questions = 2
+    tmp_path = setup_questions(number_of_questions)
+    os.chdir(tmp_path)
+
+    questions_public = question_svc.load_questions()
+
+    assert questions_public == question_svc.get_questions()
+
+
+def test_read_file(question_svc, setup_bad_questions):
+    number_of_questions = 2
+    tmp_path = setup_bad_questions(number_of_questions)
+    os.chdir(tmp_path)
+
+    with pytest.raises(Exception):  # exception on 53-54
+        (question_svc.load_local_docs(1))[0].content
+
+    with pytest.raises(Exception):  # read_document exception
+        question_svc.read_document(
+            f"{tmp_path}/es_files/questions/q1/doesntexist.extension", "foo"
+        )
+
+
+def test_load_global_docs(question_svc, setup_bad_questions):
+    number_of_questions = 3
+    tmp_path = setup_bad_questions(number_of_questions)
+    os.chdir(tmp_path)
+
+    assert len(question_svc.load_global_docs()) == 0
+
+
+def test_refresh_questions(question_svc, setup_questions):
+    number_of_questions = 2
+    tmp_path = setup_questions(number_of_questions)
+    os.chdir(tmp_path)
+
+    startingQuestions = question_svc.load_questions()
+    question_svc.refresh_questions()
+    refreshedQuestions = question_svc.load_questions()
+
+    assert startingQuestions.questions == refreshedQuestions.questions


### PR DESCRIPTION
Its been a pretty quiet week but I am gonna be busy tomorrow taking the Putnam math test (realistically I am expecting a 0) so I thought I would get this up tonight. Not sure I did this the most effective way but I have 2 fixtures that setup temporary directories: one is correct settup_questions and the other has many errors to trigger the exceptions/edge cases setup_bad_questions. Running the tests with coverage gives exactly 90% on questions.py. I am not 100% sure about the quality of this code (it runs and the tests pass) so please give comments/feedback where necessary.