### PR TITLE
Deploy Steps

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 
 # Citation: Most of the code in this Dockerfile is from the csxl.unc.edu repo. https://github.com/unc-csxl/csxl.unc.edu
-# Big thanks to Kris Jordan who wrote the origional Devcontainer and is maintainting it with an MIT license
+# Big thanks to Kris Jordan who wrote the original Devcontainer and is maintaining it with an MIT license
 
 # Install useful system utilities
 ENV TZ=America/New_York

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ database.db
 *.db
 .DS_Store
 judge0.conf
+static/
+*.tsbuildinfo
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ For more information visit our [COMP523 E-Team Website here](https://tarheels.li
 
 ## Get Programming
 
+> Note: These instructions are for setting up the development environment. Please see [here](/docs/deploy.md) for exam day setup.
+
 ### Download the Repo
 
 1. Install Docker Desktop, VSCode, and the DevContainer VSCode extension

--- a/backend/api/static_files.py
+++ b/backend/api/static_files.py
@@ -1,6 +1,9 @@
 """This file is inspired by the csxl.unc.edu project, and aims to extend the static files class to support a statically built frontend"""
 
-from fastapi.staticfiles import StaticFiles
+from fastapi import Response
+from starlette.staticfiles import StaticFiles
+from starlette.types import Scope
+import os
 
 class CustomStatic(StaticFiles):
     """Extends the StaticFiles class to support the routing conventions used in this website"""
@@ -8,3 +11,29 @@ class CustomStatic(StaticFiles):
     def __init__(self, *, directory = None, packages = None, html = False, check_dir = True, follow_symlink = False, index: str = "index.html") -> None:
         self.index = index
         super().__init__(directory=directory, packages=packages, html=html, check_dir=check_dir, follow_symlink=follow_symlink)
+
+    def lookup_path(self, path) -> tuple[str, os.stat_result | None]:
+        """Super wrapper that returns index file if path cannot be found
+        
+        Args:
+            path (str): Resource path
+            
+        Returns:
+            tuple: Full path and stat results or None if the file was not found
+        """
+        full_path, stat_result = super().lookup_path(path)
+
+        if stat_result == None:
+            full_path, stat_result = super().lookup_path(self.index)
+            return full_path, stat_result
+        else:
+            return full_path, stat_result
+
+    async def get_response(self, path: str, scope: Scope) -> Response:
+        """Adds cache-control headers for index.html"""
+
+        # Treat root path as the index file
+        if path in ["", "/", "."]:
+            path = self.index
+        
+        return await super().get_response(path, scope)

--- a/backend/api/static_files.py
+++ b/backend/api/static_files.py
@@ -1,0 +1,10 @@
+"""This file is inspired by the csxl.unc.edu project, and aims to extend the static files class to support a statically built frontend"""
+
+from fastapi.staticfiles import StaticFiles
+
+class CustomStatic(StaticFiles):
+    """Extends the StaticFiles class to support the routing conventions used in this website"""
+
+    def __init__(self, *, directory = None, packages = None, html = False, check_dir = True, follow_symlink = False, index: str = "index.html") -> None:
+        self.index = index
+        super().__init__(directory=directory, packages=packages, html=html, check_dir=check_dir, follow_symlink=follow_symlink)

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,6 @@
 """Entry of the backend for the SOTesting Environment. Sets up FastAPI and exception handlers"""
 
+from pathlib import Path
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from fastapi.middleware.gzip import GZipMiddleware
@@ -12,7 +13,7 @@ from .services.exceptions import (
     ResourceNotAllowedException,
 )
 
-from .api import team, auth, question, docs, submission
+from .api import team, auth, question, docs, submission, static_files
 
 __authors__ = ["Andrew Lockard", "Mustafa Aljumayli"]
 
@@ -50,7 +51,7 @@ feature_apis = [team, auth, question, docs, submission]
 for feature_api in feature_apis:
     app.include_router(feature_api.api)
 
-app.mount("/", StaticFiles(directory="static"), name="React_Frontend")
+app.mount("/", static_files.CustomStatic(directory=Path("./static")))
 
 
 # TODO: Add Custom HTTP response exception handlers here for any custom Exceptions we create

--- a/backend/main.py
+++ b/backend/main.py
@@ -5,7 +5,6 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.staticfiles import StaticFiles
 
 from .services.exceptions import (
     InvalidCredentialsException,

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
 
 from .services.exceptions import (
     InvalidCredentialsException,
@@ -49,7 +50,7 @@ feature_apis = [team, auth, question, docs, submission]
 for feature_api in feature_apis:
     app.include_router(feature_api.api)
 
-# TODO: Mount the static website built from the react application so the FastAPI server can serve it
+app.mount("/", StaticFiles(directory="static"), name="React_Frontend")
 
 
 # TODO: Add Custom HTTP response exception handlers here for any custom Exceptions we create

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -87,7 +87,7 @@ Use the tools outlined in the [ES Documentation](event_supervisor.md) to create 
 Once you have finished creating your exam, you can run the server with this command:
 
 ```bash
-uvicorn backend.main:app --port=[PORT_NUMBER] --host=[HOST_NUMBER]
+uvicorn --port=[PORT_NUMBER] --host=[HOST_NUMBER] backend.main:app 
 ```
 
 Note that the port and host numbers are optional.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -84,7 +84,7 @@ Use the tools outlined in the [ES Documentation](event_supervisor.md) to create 
 
 ### Run the Server
 
-Once you have finished creating your exam, you can run the server with this command:
+Once you have finished creating your exam, you can run the server with this command, while in the home (`SOTestingEnv`) directory:
 
 ```bash
 uvicorn --port=[PORT_NUMBER] --host=[HOST_NUMBER] backend.main:app 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,94 @@
+# "Deployment" / Exam Day Setup Instructions
+
+Follow these instructions for exam day setup. 
+Some of these only need to be completed once, but all will need to be repeated if there is an update to the software.
+
+### Download the Repo
+
+1. Install Docker Desktop, VSCode, and the DevContainer VSCode extension
+2. Clone the repo into VSCode and open it
+
+### Setup [Judge0](https://github.com/judge0/judge0)
+
+*Note: This is to be completed *outside* the devcontainer
+
+1. Download the [judge0 config file](https://github.com/judge0/judge0/blob/ffd7a48cc6da86d6ac155ef10dbd67d02736070b/judge0.conf)
+2. Place the file in the `judge0` directory
+3. Visit [this website](https://www.random.org/passwords/?num=1&len=32&format=plain&rnd=new) to generate a random password
+4. Use this password as the `REDIS_PASSWORD` variable in the `judge0.conf` file.
+5. Visit [this website again](https://www.random.org/passwords/?num=1&len=32&format=plain&rnd=new) to generate a new random password
+6. Use this new password as the `POSTGRES_PASSWORD` variable in the `judge0.conf` file.
+
+> Note: the following judge0 setup steps must be run every time you wish to run the server
+
+7. Make sure your current working directory is set to `judge0` (`cd judge0`)
+8. Run `bash start.sh` to launch the judge0 server
+9. The first time you run this: put some pizza in the oven
+
+> When you wish to exit development don't forget to stop judge0, either via `docker-compose down` inside the `judge0` directory (make sure you are outside the devcontainer!) or stopping the container in Docker Desktop.
+
+**IMPORTANT NOTE FOR OS X USERS (And maybe others)**
+
+Depending on your docker version, the Judge0 workers may not run properly.
+
+To fix the issue, you need modify the Docker Group settings...
+
+1. Locate the `settings-store.json` file (or `settings.json` for Docker Desktop versions 4.34 and earlier) at:
+
+- Mac: `~/Library/Group\ Containers/group.com.docker/settings-store.json`
+- Windows: `C:\Users\[USERNAME]\AppData\Roaming\Docker\settings-store.json`
+- Linux: `~/.docker/desktop/settings-store.json`
+
+Open the path in your terminal (Mac OS X zsh example)
+
+```zsh
+open ~/Library/Group\ Containers/group.com.docker/settings-store.json
+```
+
+2. Find `"DeprecatedCgroupv1"`,
+   - If it exists, set to `true`
+   - If it does not, append `"DeprecatedCgroupv1": true,` to the json.
+
+### Enter the DevContainer
+
+For the moment, we will continue to support running the testing envrionment out of a devcontainer only.
+
+1. Navigate back to the repo in VSCode
+2. Press `Ctrl+Shift+P` on windows (`Cmd+Shift+P` on mac) to open the command pallet and run `Dev Containers: Build and Reopen in Container` (In the future to open you can just use `Dev Containers: Reopen in Container`)
+3. Grab some water while the container builds
+
+### Build the Frontend
+
+1. `cd frontend`
+2. `npm i` to install node dependencies
+3. `npm run build` to build the frontend
+4. `cd ..` to return to the top level directory
+
+### Setup Environment Variables
+
+1. `cd backend`
+2. Generate a random secret key via: `openssl rand -hex 32`
+3. Create a new file called `.env.development` with the following contents:
+
+```
+SECRET_KEY=<Your Generated Secret Key>
+ACCESS_TOKEN_EXPIRE_MINUTES=75
+```
+
+Note that you may want to modify the `ACCESS_TOKEN_EXPIRE_MINUTES` to be longer than you test period is.
+At the end of this time, the login tokens will invalidate and the user will need to log in again.
+
+### Create Your Exam
+
+Use the tools outlined in the [ES Documentation](event_supervisor.md) to create your exam in the `es_files` directory.
+
+### Run the Server
+
+Once you have finished creating your exam, you can run the server with this command:
+
+```bash
+uvicorn backend.main:app --port=[PORT_NUMBER] --host=[HOST_NUMBER]
+```
+
+Note that the port and host numbers are optional.
+

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5626,9 +5626,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "dev": true,
       "funding": [
         {

--- a/frontend/src/pages/Question.tsx
+++ b/frontend/src/pages/Question.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import SubmissionWidget from "../components/SubmissionWidget";
 import { QuestionsPublic, Question, Document } from "../models/questions";
 import LeftSideBar from "../components/LeftSideBar";


### PR DESCRIPTION
## Features

This PR adds instructions on how to "pseudo deploy" the website for production. Specifically in [/docs/deploy.md](/docs/deploy.md). This PR also adds in some small functionality taken from the csxl website to support redirecting the routing to the built html when the root route is entered (i.e. `/`, `.`, and the blank route).

I'm calling these deployment steps "pseudo" since it still requires lots of manual operations to deploy the website. In a better world the whole project would just live as a docker image, but this will do the trick for now.

## Testing

To test this I made sure I could navigate through the built version of the website and submit code.

## Why?

I believe that running the code like this will will make the user experience much faster since there are less moving parts than before. This will also remove the unnecessary server reloading that occurs when you run the development server (via `honcho start`) when a student submits any code.

## Meme

![meme](https://i.redd.it/7t89454ga27e1.jpeg)